### PR TITLE
Add workflow to run `npm run bundle` after dependabot updates

### DIFF
--- a/.github/workflows/dependabot-bundle.yaml
+++ b/.github/workflows/dependabot-bundle.yaml
@@ -1,0 +1,33 @@
+name: Dependabot Bundle
+on: pull_request
+
+permissions: {}
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    if:
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.commits == 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.DEPENDABOT_BUNDLE_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Bundle dist
+        run: npm run bundle
+
+      - name: Commit dist
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: '[dependabot skip] Bundle dist'

--- a/.github/workflows/dependabot-bundle.yaml
+++ b/.github/workflows/dependabot-bundle.yaml
@@ -10,10 +10,16 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.commits == 1
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GW2LOAD_BOT_APP_ID }}
+          private-key: ${{ secrets.GW2LOAD_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.DEPENDABOT_BUNDLE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The new `dependabot-bundle.yaml` workflow runs on dependabot PRs and commits changes to the repo after running `npm run bundle`. It only runs when the PR has a single commit, to prevent infinite recursion or updating anything added manually.

It uses the `GW2LOAD_BOT_APP_ID ` and `GW2LOAD_BOT_APP_PRIVATE_KEY` secrets to create a token.