### PR TITLE
Fix `dependabot-bundle` workflow

### DIFF
--- a/.github/workflows/dependabot-bundle.yaml
+++ b/.github/workflows/dependabot-bundle.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node.js


### PR DESCRIPTION
The workflow failed in #25, which might have been caused by checking out as detached head (not sure this is the real error reason though, because it worked in the past and the push step correctly pushes to the expected branch).