### PR TITLE
Change action to use `node24`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
 outputs: {}
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
`node20` will be deprecated next year: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
